### PR TITLE
Fix chaining redirects with query params

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,17 +19,27 @@ function removeTrailingSlashes(opts) {
         }
 
         let path;
+        let querystring = '';
 
         // We have already done a redirect and we will continue if we are in chained mode
         if (opts.chained && ctx.status === 301) {
-            path = getPath(ctx.response.get('Location'), ctx.querystring);
+            const location = ctx.response.get('Location') || '';
+
+            // We can't use ctx.querystring because it may not be up to date
+            const parsedLocation = location.match(/\?(.*)$/);
+            if (parsedLocation && parsedLocation[1]) {
+                querystring = parsedLocation[1];
+            }
+
+            path = getPath(location, querystring);
         } else if (ctx.status !== 301) {
+            querystring = ctx.querystring;
             path = getPath(ctx.originalUrl, ctx.querystring);
         }
 
         if (path && haveSlash(path)) {
             path = path.slice(0, -1);
-            const query = ctx.querystring.length ? '?' + ctx.querystring : '';
+            const query = querystring.length ? '?' + querystring : '';
 
             ctx.status = 301;
             ctx.redirect(path + query);

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,24 @@ describe('koa-remove-trailing-slashes', () => {
                 expect(mock.ctx.status).toBe(301);
             });
 
+            it('should correctly chain redirect if path has trailing slash and query params', async () => {
+                const mock = createMock('/fOo/?baz=1', 'baz=1');
+
+                // Mock that something has made a redirect before us
+                mock.ctx.status = 301;
+                mock.ctx.body = 'Redirecting to …';
+                mock.ctx.response = {
+                    get() {
+                        return '/foo/?bar=1';
+                    }
+                };
+
+                await removeTrailingSlashes()(mock.ctx, mock.next);
+
+                expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/foo?bar=1');
+                expect(mock.ctx.status).toBe(301);
+            });
+
             it('should redirect on url and path has trailing slash', async () => {
                 const mock = createMock('/foo/');
                 await removeTrailingSlashes()(mock.ctx, mock.next);

--- a/test/index.js
+++ b/test/index.js
@@ -86,7 +86,7 @@ describe('koa-remove-trailing-slashes', () => {
                 expect(mock.ctx.status).toBe(301);
             });
 
-            it.only('should not use old query params when processing chain redirects', async () => {
+            it('should not use old query params when processing chain redirects', async () => {
                 const mock = createMock('/fOo/?baz=1', 'baz=1');
 
                 // Mock that something has made a redirect before us

--- a/test/index.js
+++ b/test/index.js
@@ -86,6 +86,24 @@ describe('koa-remove-trailing-slashes', () => {
                 expect(mock.ctx.status).toBe(301);
             });
 
+            it.only('should not use old query params when processing chain redirects', async () => {
+                const mock = createMock('/fOo/?baz=1', 'baz=1');
+
+                // Mock that something has made a redirect before us
+                mock.ctx.status = 301;
+                mock.ctx.body = 'Redirecting to …';
+                mock.ctx.response = {
+                    get() {
+                        return '/foo/barrr/';
+                    }
+                };
+
+                await removeTrailingSlashes()(mock.ctx, mock.next);
+
+                expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/foo/barrr');
+                expect(mock.ctx.status).toBe(301);
+            });
+
             it('should redirect on url and path has trailing slash', async () => {
                 const mock = createMock('/foo/');
                 await removeTrailingSlashes()(mock.ctx, mock.next);


### PR DESCRIPTION
# Summary

When chaining redirect query string was taken from old url and not the one we were redirecting to.

This shouldn't be a breaking change for anyone and could be released as `patch` bump in my opinion.

## Example

We had url like `/nyheter/nyhet/i/Wbe93r?utm_source=related_articles` which was redirecting to `/nyheter/nyhet/i/awJPd4/retter-mobilreklame-mot-unge` but since `getPath` https://github.com/vgno/koa-remove-trailing-slashes/blob/master/index.js#L25  used `ctx.querystring` which wasn't up to date it sliced the length of the old query string from path https://github.com/vgno/koa-remove-trailing-slashes/blob/master/index.js#L49-L51. In this unfortunate case the length of old `ctx.querystring` was equal to slug `retter-mobilreklame-mot-unge` and we ended with path `/nyheter/nyhet/i/awJPd4/` which then gets redirected by this plugin to `/nyheter/nyhet/i/Wbe93r?utm_source=related_articles` (old `ctx.querystring` again) and we end up with infinite redirect loop.